### PR TITLE
docs & test: add README and basic AirdropNFT test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This has NOT been audited.  Use at your own risk.
 
 This is a simple swap contract that utilizes the cosmos bank module on the Kii EVM testnet.  It is meant to swap EVM kii tokens with internal cosmos sKii tokens and vice versa.
+
+## 🚀 How to Run This Project
+
+### Install Dependencies
+```bash
+npm install

--- a/test/basic-test.ts
+++ b/test/basic-test.ts
@@ -1,0 +1,12 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+describe("Basic Deployment", function () {
+  it("Should deploy AirdropNFT contract", async function () {
+    const ContractFactory = await ethers.getContractFactory("AirdropNFT");
+    const contract = await ContractFactory.deploy();
+    await contract.waitForDeployment();
+
+    expect(await contract.getAddress()).to.properAddress;
+  });
+});


### PR DESCRIPTION
- Added a basic test for the AirdropNFT contract to ensure successful deployment
- Created a clear and simple README for onboarding contributors
- Removed default Lock.ts test from Hardhat boilerplate