### PR TITLE
Codeowner, stale-pr and codeql 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AndresRamirez9912

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,24 @@
+# .github/workflows/codeql-analysis.yml
+name: "CodeQL"
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+    # required for all workflows
+    security-events: write
+
+    # required to fetch internal or private CodeQL packs
+    packages: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,14 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *' 
+  workflow_dispatch:     
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This PR adds two improvements to the repository configuration:

- Adds a `CODEOWNERS` file assigning @AndresRamirez9912 as the maintainer of the repository.
- Adds a `stale-pr.yml` GitHub Actions workflow to automatically mark and close stale pull requests and issues.

These changes are part of a broader effort to improve the maintainability and hygiene of our public repositories, ensuring code reviews are properly assigned and inactive contributions are periodically reviewed or cleaned up.

## Type of change

Please delete options that are not relevant.

- [x] chore (Updates on dependencies, gitignore, etc)

# How Has This Been Tested?

These are configuration files and do not affect the application runtime.

- [x] Verified CODEOWNERS syntax locally and confirmed GitHub picks it up automatically for review assignment.
- [x] Verified `stale-pr.yml` configuration against the [official documentation](https://github.com/actions/stale) and based on the working setup in `kiijs-sdk`.

No application logic was changed. No tests are required for this PR.
